### PR TITLE
set up knex configuration file to connect database

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,15 @@
+import "dotenv/config";
+// Update with your config settings.
+
+/**
+ * @type { Object.<string, import("knex").Knex.Config> }
+ */
+export default {
+  client: 'mysql2',
+  connection: {
+    host: process.env.DB_HOST,
+    database: process.env.DB_NAME,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+  }
+};


### PR DESCRIPTION
i still have the .env file in .gitignore, so its not pushed to github, you might need to have your own .env file as following: 

PORT=8080
DB_NAME=instock  # Replace with your actual database name
DB_USER=root     # Replace with your DB username
DB_PASSWORD=rootroot  # Replace with your DB password

since our database password might different, let me know if you have a better way to manage the .env file!